### PR TITLE
Fix lyrics cleanup

### DIFF
--- a/Zeenox/Services/MusicService.cs
+++ b/Zeenox/Services/MusicService.cs
@@ -165,6 +165,11 @@ public partial class MusicService
         first.ChildNodes.RemoveAt(0);
         while (first.ChildNodes[0].Name == "br" || first.ChildNodes[0].InnerText.Contains("["))
         {
+            if (first.ChildNodes[0].InnerText.Contains("["))
+            {
+                while(first.ChildNodes[0].Name != "br")
+                    first.ChildNodes.RemoveAt(0);
+            }
             first.ChildNodes.RemoveAt(0);
         }
 


### PR DESCRIPTION
This pull request addresses a critical issue within the music lyrics cleanup algorithm. Previously, the algorithm failed to delete text enclosed within square brackets if HTML tags were present within them.

To resolve this issue effectively, this update introduces a straightforward workaround. Now, when the algorithm encounters an opening square bracket, it removes the nodes until it reaches a <br> tag, ensuring seamless handling of HTML tags within the square bracketed text.