### PR TITLE
Fix handling of first line in lyrics

### DIFF
--- a/Zeenox/Services/MusicService.cs
+++ b/Zeenox/Services/MusicService.cs
@@ -167,7 +167,6 @@ public partial class MusicService
         }
 
         var first = element.First();
-        first.ChildNodes.RemoveAt(0);
         while (first.ChildNodes[0].Name == "br" || first.ChildNodes[0].InnerText.Contains('['))
         {
             if (first.ChildNodes[0].InnerText.Contains('['))


### PR DESCRIPTION
The first line of some lyrics was wrong due to removing the first HTML tag forcefully. The solution was to not remove the first tag so the algorithm could process the chunk of tags.